### PR TITLE
Implement error on package:symbol resolution and optimize add/sub ins…

### DIFF
--- a/lib/read.lisp
+++ b/lib/read.lisp
@@ -308,7 +308,15 @@
          (destructuring-bind (pkg-name symbol-name interned-p)
              (%has-package-p string)
            (if pkg-name
-               (intern symbol-name pkg-name)
+               (if interned-p
+                   (intern symbol-name pkg-name)
+                   (destructuring-bind (symbol place)
+                       (find-symbol symbol-name pkg-name)
+                     (if (and symbol (eq place :external))
+                         symbol
+                         (signal 'simple-error "No external symbol in package"
+                                 symbol-name
+                                 pkg-name))))
                (intern string *package*))))))
 
 


### PR DESCRIPTION
…tructions

Before, when trying to access a private/internal symbol with the
single colon package specifier e.g.: lispyboi:%case, if the symbol
%case wasn't exported, the symbol would incorrectly resolve. Now it
throw an error saying so.

Also implemented a minimally branching type deduction algorithm for
the add and sub VM instructions. It works by assigning 9 distinct
values: 4 correct and 5 incorrect, via fast arithmetic operations
and then switching over which operation to do without explicit type-
checking.

    a' = 0 if a is not number
         1 if a is fixnum
         4 if a is float

    b' = 0 if b is not number
         2 if b is fixnum
         8 if b is float

    c' = a' + b'

    if c' == 3: both a and b are fixnum
    if c' == 6: a is float and b is fixnum
    if c' == 9: a is fixnum and b is float
    if c' == 12: both a and b are float

    else: // just error but for completeness
        if c' == 0: both a and b are not numbers
        if c' == 1: a is fixnum, b is not number
        if c' == 4: a is float, b is not number
        if c' == 2: a is not number, b is fixnum
        if c' == 8: a is not number, b is float